### PR TITLE
Relax pins for plugins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ source:
     folder: dbt-snowflake
 
 build:
-  number: 2
+  number: 3
   noarch: python
 
 outputs:
@@ -41,11 +41,11 @@ outputs:
         - python >=3.6
       run:
         - python >=3.6
-        - {{ pin_subpackage("dbt-bigquery", exact=True) }}
+        - {{ pin_subpackage("dbt-bigquery", min_pin='x.x', max_pin='x.x') }}
         - {{ pin_subpackage("dbt-core", exact=True) }}
-        - {{ pin_subpackage("dbt-postgres", exact=True) }}
-        - {{ pin_subpackage("dbt-redshift", exact=True) }}
-        - {{ pin_subpackage("dbt-snowflake", exact=True) }}
+        - {{ pin_subpackage("dbt-postgres", min_pin='x.x', max_pin='x.x') }}
+        - {{ pin_subpackage("dbt-redshift", min_pin='x.x', max_pin='x.x') }}
+        - {{ pin_subpackage("dbt-snowflake", min_pin='x.x', max_pin='x.x') }}
 
     test:
       imports:
@@ -141,7 +141,7 @@ outputs:
         - python >=3.6
         - boto3 >=1.4.4,<2.0.0
         - {{ pin_subpackage("dbt-core", exact=True) }}
-        - {{ pin_subpackage("dbt-postgres", exact=True) }}
+        - {{ pin_subpackage("dbt-postgres", min_pin='x.x', max_pin='x.x') }}
 
     test:
       imports:


### PR DESCRIPTION
Partially addresses https://github.com/conda-forge/dbt-feedstock/pull/60#issuecomment-957727034 by relaxing the pinning of the plugins to the major/minor versions.

...if I correctly understand the conda-build docs.

This recipe may still be problematic if for example `dbt-core` bumps the patch version while there are no corresponding patch versions for the other plugins. I'm not sure how to solve this.

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
