### PR TITLE
Update to 1.7.2.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.7" %}
+{% set version = "1.7.2" %}
 
 package:
   name: dbt
@@ -6,10 +6,10 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/d/dbt-core/dbt-core-{{ version }}.tar.gz
-    sha256: 09c76b6b9bde3f8e00d24451a18af5b1c8151abfda9884603ce9d5bafc24c556
+    sha256: ec0a06a5015a830f63ad3fd506473cbf12edafeae89cf2d611a10836788da603
     folder: dbt-core
   - url: https://pypi.io/packages/source/d/dbt-postgres/dbt-postgres-{{ version }}.tar.gz
-    sha256: e6109322084316116d44717e57fb249edad8cf8ee05e83840a986c825cae07a9
+    sha256: 11d3822eec1d62ad70eb7497b41fb86bfd44bcb8d8b449d6dc35f9bd5cfa8982
     folder: dbt-postgres
 
 build:


### PR DESCRIPTION
- sha256s from: curl https://pypi.org/pypi/dbt-core/1.7.2/json and curl https://pypi.org/pypi/dbt-postgres/1.6.7/json
